### PR TITLE
docs: remove agent skill management references

### DIFF
--- a/features/agent/index.md
+++ b/features/agent/index.md
@@ -84,8 +84,6 @@ The agent tool registry currently includes these tools. Skills and remote-node t
 | `navigate` | Open pages in the Dagu UI |
 | `ask_user` | Prompt the user with options or free-text input |
 | `delegate` | Spawn sub-agents for parallel tasks |
-| `use_skill` | Execute a skill from the skill store (when skills are configured) |
-| `search_skills` | Search available skills by query (when skills are configured) |
 | `remote_agent` | Delegate tasks to agents on remote nodes (when remote nodes are configured) |
 | `list_contexts` | List available remote nodes for `remote_agent` (when remote nodes are configured) |
 
@@ -139,7 +137,6 @@ Agent configuration is stored in `{DAGU_HOME}/data/agent/config.json`. A typical
       "denyBehavior": "ask_user"
     }
   },
-  "enabledSkills": [],
   "selectedSoulId": "",
   "webSearch": { "enabled": true }
 }

--- a/features/agent/settings/controls.md
+++ b/features/agent/settings/controls.md
@@ -20,7 +20,7 @@ Examples include:
 - `ask_user`
 - `delegate`
 
-The exact tool list is loaded from the backend. Skill-related tools and remote-node tools only appear when those features are configured.
+The exact tool list is loaded from the backend. Remote-node tools only appear when remote nodes are configured.
 
 See [Tools Reference](/features/agent/tools) for what each tool does.
 

--- a/features/agent/step.md
+++ b/features/agent/step.md
@@ -46,7 +46,6 @@ steps:
 |-------|------|---------|-------------|
 | `model` | string | global default | Model ID from Agent Settings. Overrides the default model for this step. |
 | `tools` | object | — | Tool selection and bash policy. See [Tools](#tools). |
-| `skills` | string[] | — | Skill IDs the agent is allowed to use. If omitted, falls back to globally enabled skills. |
 | `soul` | string | — | Soul ID for this step's identity. When omitted, inherits from `defaults.agent.soul`. |
 | `memory` | object | `{ enabled: false }` | When `enabled: true`, loads global and per-DAG memory into the agent context. See [Memory](/features/agent/memory). |
 | `prompt` | string | — | Additional instructions appended to the built-in system prompt. |
@@ -99,7 +98,6 @@ steps:
 |-------|------|-------------|
 | `model` | string | Default model ID for agent steps |
 | `tools` | object | Default tool selection and bash policy |
-| `skills` | string[] | Default skill IDs |
 | `soul` | string | Default soul ID |
 | `memory` | object | Default memory configuration |
 | `prompt` | string | Default additional system prompt instructions |
@@ -118,8 +116,6 @@ The agent step has access to these tools:
 | `read` | Read file contents with line numbers (max 1MB, 2000 lines default) |
 | `patch` | Create, edit, or delete files |
 | `think` | Record reasoning without executing actions |
-| `use_skill` | Execute a skill from the skill store (available when skills are configured) |
-| `search_skills` | Search available skills by query (available when skills are configured) |
 | `remote_agent` | Delegate tasks to agents through remote CLI contexts (available when contexts are configured) |
 | `list_contexts` | List available remote CLI contexts for `remote_agent` (available when contexts are configured) |
 | `output` | Write the final result to stdout (step-only, see [Output Capture](#output-capture)) |

--- a/features/agent/tools.md
+++ b/features/agent/tools.md
@@ -139,13 +139,11 @@ Spawn sub-agents that execute tasks in parallel.
 |-----------|------|----------|-------------|
 | `tasks` | array | Yes | List of sub-task objects (max: 8) |
 | `tasks[].task` | string | Yes | Description of the sub-task for the sub-agent |
-| `tasks[].skills` | string[] | No | Skill IDs to pre-load into the sub-agent context |
 
 Each sub-agent:
 - Runs in a separate session linked to the parent via `ParentSessionID`
 - Receives the same system prompt and all tools except `delegate`, `ask_user`, and `navigate`
 - Does not receive the parent conversation history
-- Can start with specific skills pre-loaded via `tasks[].skills`
 - Executes its full tool-calling loop, then returns its last assistant text response as a summary to the parent
 
 Sub-agents inherit the tool policy configured in agent settings. In safe mode, bash commands denied with `ask_user` behavior are also denied because the approval prompt cannot be delivered to the user.
@@ -189,43 +187,11 @@ Task descriptions in the output are truncated to 60 characters.
       "task": "Run 'df -h' and report any filesystems above 80% usage"
     },
     {
-      "task": "Read /opt/app/config/cron.yaml and verify all cron expressions are valid",
-      "skills": ["linux-ops"]
+      "task": "Read /opt/app/config/cron.yaml and verify all cron expressions are valid"
     }
   ]
 }
 ```
-
----
-
-## use_skill
-
-Load knowledge from a configured skill.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `skill_id` | string | Yes | Skill ID to load |
-
-**Availability**: Only shown when a skill store is configured.
-
-**Output**: The tool returns the skill knowledge wrapped in a `<skill ...>` block for the model to use in the current task.
-
----
-
-## search_skills
-
-Search configured skills by keyword or tag without loading full skill content.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `query` | string | No | | Keyword matched against name, description, and tags |
-| `tags` | string[] | No | | Tags that must all match |
-| `page` | integer | No | 1 | Page number |
-| `per_page` | integer | No | 50 | Results per page (max: 200) |
-
-**Availability**: Only shown when a skill store is configured.
-
-**Output**: Paginated skill summaries including ID, name, description, and tags.
 
 ---
 

--- a/getting-started/ai-agent.md
+++ b/getting-started/ai-agent.md
@@ -31,8 +31,6 @@ The agent can use these built-in tools. Some are only available when the corresp
 | `navigate` | Open pages in the Dagu UI |
 | `ask_user` | Prompt the user with options or free-text input |
 | `delegate` | Spawn sub-agents for parallel tasks |
-| `use_skill` | Execute a skill from the skill store (when skills are configured) |
-| `search_skills` | Search available skills by query (when skills are configured) |
 | `remote_agent` | Delegate tasks to agents on remote nodes (when remote nodes are configured) |
 | `list_contexts` | List available remote nodes for `remote_agent` (when remote nodes are configured) |
 

--- a/overview/web-ui.md
+++ b/overview/web-ui.md
@@ -69,7 +69,7 @@ Click the **Agent** button at the bottom-left corner of any page.
 - Execute shell commands subject to the configured bash policy
 - Read files and edit repository content
 - Navigate to UI pages
-- Use skills or remote nodes when those features are configured
+- Delegate tasks to remote nodes when configured
 
 ### Configuration
 

--- a/server-admin/git-sync.md
+++ b/server-admin/git-sync.md
@@ -1,6 +1,6 @@
 # Git Sync
 
-Git Sync synchronizes local DAG files and agent files (memory, skills, souls) with a remote Git repository.
+Git Sync synchronizes local DAG files and agent files (memory, souls) with a remote Git repository.
 
 ## Tracked Files and Item IDs
 
@@ -12,7 +12,6 @@ Git Sync tracks items by `itemId` — the file path relative to the DAGs directo
 | `subdir/report.yml` | `subdir/report` | `dag` |
 | `memory/MEMORY.md` | `memory/MEMORY` | `memory` |
 | `memory/dags/my-dag/MEMORY.md` | `memory/dags/my-dag/MEMORY` | `memory` |
-| `skills/my-skill/SKILL.md` | `skills/my-skill/SKILL` | `skill` |
 | `souls/persona.md` | `souls/persona` | `soul` |
 
 ## File Scanning Rules
@@ -21,7 +20,7 @@ Implemented in `internal/gitsync/service.go`.
 
 ### Remote scan
 
-Includes files with extensions `.yaml`, `.yml`, and `.md`. Files with `.md` extension are only accepted when the item ID starts with `memory/`, `skills/`, or `souls/`.
+Includes files with extensions `.yaml`, `.yml`, and `.md`. Files with `.md` extension are only accepted when the item ID starts with `memory/` or `souls/`.
 
 ### Local untracked scan
 
@@ -29,7 +28,6 @@ Discovers local files not yet in sync state:
 
 - **DAGs**: `.yaml` and `.yml` files in the root of `{dags_dir}/`. Flat scan, not recursive.
 - **Memory**: any `.md` file under `memory/`. Recursive walk through all subdirectories.
-- **Skills**: only `skills/<name>/SKILL.md`. Scans one level of subdirectories under `skills/`, looking specifically for `SKILL.md` in each.
 - **Souls**: `souls/*.md`. Flat scan, not recursive.
 
 ## Configuration
@@ -333,7 +331,7 @@ Response:
 
 - `items` are sorted by `filePath`.
 - For `kind=dag`, `filePath` is `itemId + ".yaml"`.
-- For `kind=memory`, `kind=skill`, or `kind=soul`, `filePath` is `itemId + ".md"`.
+- For `kind=memory` or `kind=soul`, `filePath` is `itemId + ".md"`.
 - `displayName` equals `filePath`.
 
 ### Diff
@@ -480,7 +478,7 @@ DAGState fields:
 | Field | Type | Description |
 |---|---|---|
 | `status` | string | `synced`, `modified`, `untracked`, `conflict`, or `missing` |
-| `kind` | string | `dag`, `memory`, `skill`, or `soul` |
+| `kind` | string | `dag`, `memory`, or `soul` |
 | `baseCommit` | string | Commit hash when item was last synced |
 | `lastSyncedHash` | string | Content hash at last sync (`sha256:...`) |
 | `lastSyncedAt` | datetime | When item was last synced |

--- a/writing-workflows/step-defaults.md
+++ b/writing-workflows/step-defaults.md
@@ -38,7 +38,7 @@ See [YAML Specification - Step Defaults](/writing-workflows/yaml-specification#s
 
 **Override fields** (`retry_policy`, `continue_on`, `repeat_policy`, `timeout_sec`, `mail_on_error`, `signal_on_stop`): The default is applied only when the step does not set its own value. When a step defines the field, the step's value is used entirely — there is no field-level merging within the object.
 
-**Agent fields** (`agent`): Defaults are applied per subfield rather than as a whole-object replacement. Supported default subfields are `model`, `tools`, `skills`, `soul`, `memory`, `prompt`, `max_iterations`, and `safe_mode`.
+**Agent fields** (`agent`): Defaults are applied per subfield rather than as a whole-object replacement. Supported default subfields are `model`, `tools`, `soul`, `memory`, `prompt`, `max_iterations`, and `safe_mode`.
 
 **Additive fields** (`env`, `preconditions`): Default entries are prepended before the step's own entries. Both sets are present at runtime.
 

--- a/writing-workflows/yaml-specification.md
+++ b/writing-workflows/yaml-specification.md
@@ -206,7 +206,7 @@ The `defaults` block accepts the following fields:
 **Merge rules:**
 
 - **Override fields** (`retry_policy`, `continue_on`, `repeat_policy`, `timeout_sec`, `mail_on_error`, `signal_on_stop`): Applied only when the step does not set its own value. A step-level value fully replaces the default.
-- **Agent fields** (`agent`): Applied per subfield rather than as a whole-object replacement. Supported default subfields are `model`, `tools`, `skills`, `soul`, `memory`, `prompt`, `max_iterations`, and `safe_mode`.
+- **Agent fields** (`agent`): Applied per subfield rather than as a whole-object replacement. Supported default subfields are `model`, `tools`, `soul`, `memory`, `prompt`, `max_iterations`, and `safe_mode`.
 - **Additive fields** (`env`, `preconditions`): Default entries are prepended before the step's own entries. Both the default and step values are present at runtime.
 
 Unknown keys inside `defaults` cause a validation error.


### PR DESCRIPTION
## Summary
- Remove `use_skill` and `search_skills` tool documentation from agent tools reference and tool tables
- Remove `skills` field from agent step config and step defaults docs
- Remove skill entries from git-sync tracked files and item kinds
- Remove `enabledSkills` from config JSON example
- Update web-ui capability description

References to `dagu ai install` (external AI coding tool integration) are preserved — that feature is unrelated to the removed in-app skill management.

Companion to dagucloud/dagu#1988.

## Test plan
- [x] Verified no stale `use_skill`/`search_skills`/`enabledSkills` references remain
- [x] All `dagu ai install` documentation preserved intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Removed skill-store tools (`use_skill`, `search_skills`) from agent documentation
  * Removed skills-related configuration options from agent setup guides
  * Updated agent capabilities to focus on remote node delegation
  * Removed skills from Git Sync tracked item types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->