### PR TITLE
docs: add git checkout action docs

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -130,6 +130,7 @@ const fullSidebar = [
       { text: "HTTP", link: "/step-types/http" },
       { text: "SSH", link: "/step-types/ssh" },
       { text: "SFTP", link: "/step-types/sftp" },
+      { text: "Git", link: "/step-types/git" },
       { text: "Router", link: "/step-types/router" },
       { text: "JQ", link: "/step-types/jq" },
       { text: "S3", link: "/step-types/s3" },

--- a/getting-started/concepts.md
+++ b/getting-started/concepts.md
@@ -212,6 +212,22 @@ steps:
 
 See [HTTP](/step-types/http) for more details.
 
+### Git
+
+Clone or update a repository during a workflow run:
+
+```yaml
+steps:
+  - id: checkout_source
+    action: git.checkout
+    with:
+      repository: https://github.com/example/app.git
+      ref: main
+      path: ./workspace/app
+```
+
+See [Git](/step-types/git) for more details.
+
 ### Custom Step Types
 
 Define reusable step types in `step_types` when you want a typed wrapper around a builtin step type:

--- a/index.md
+++ b/index.md
@@ -58,7 +58,7 @@ Dagu fits teams that already have operational work spread across scripts, cron j
   </div>
   <div class="real-world-usecase">
     <h3>GitHub-driven Workflows</h3>
-    <p><strong>Run:</strong> PR validation, preview deployments, release workflows, check reruns, and repository dispatches from GitHub.</p>
+    <p><strong>Run:</strong> PR validation, preview deployments, release workflows, source checkouts, check reruns, and repository dispatches from GitHub.</p>
     <p><strong>Why Dagu fits:</strong> GitHub stays the trigger source while Dagu executes the DAG on your licensed server and reports checks, reactions, and comments back to GitHub.</p>
   </div>
   <div class="real-world-usecase">
@@ -200,6 +200,7 @@ Common built-in step types include:
 | `kubernetes`, `k8s` | Run a step as a Kubernetes workload |
 | `ssh` | Remote command execution |
 | `sftp` | Remote file transfer |
+| `git` | Clone or update Git repositories |
 | `http` | HTTP requests |
 | `postgres`, `sqlite` | SQL queries |
 | `redis` | Redis commands and scripts |
@@ -413,6 +414,8 @@ See [Examples](/writing-workflows/examples) for more patterns.
 Dagu supports Git sync to keep DAG definitions, agent markdown files, and managed documents version-controlled. Enable `DAGU_GITSYNC_ENABLED=true` with a repository URL, and Dagu pulls tracked files from a Git branch. Optional auto-sync polls the repository at a configurable interval (default 300s). Supports token and SSH authentication.
 
 See [Git Sync](/server-admin/git-sync) for configuration.
+
+Use `action: git.checkout` inside a workflow when a DAG step needs to clone or update an arbitrary source repository during execution. See [Git](/step-types/git) for the action reference.
 
 GitHub Integration is separate from Git Sync. Use it when GitHub events, PR comments, releases, check reruns, `workflow_dispatch`, or `repository_dispatch` should trigger a DAG that runs on your licensed Dagu server. See [GitHub Integration](/github-integration/) for setup and examples.
 

--- a/step-types/docker.md
+++ b/step-types/docker.md
@@ -637,4 +637,4 @@ steps:
     command: go build -o ${OUTPUT}
 ```
 
-See [parallel.items](/writing-workflows/parallel) for full fan-out options.
+See [Parallel Execution](/writing-workflows/execution-control#parallel-execution) for full fan-out options.

--- a/step-types/git.md
+++ b/step-types/git.md
@@ -1,0 +1,186 @@
+# Git
+
+Checkout source repositories from a DAG step without wrapping `git clone` and `git fetch` in shell scripts.
+
+`action: git.checkout` clones the repository when the target path does not exist, or fetches and updates an existing checkout when the target is already a Git repository.
+
+## Basic Usage
+
+```yaml
+steps:
+  - id: checkout_source
+    action: git.checkout
+    with:
+      repository: https://github.com/example/app.git
+      ref: main
+      path: ./workspace/app
+```
+
+Relative `path` values resolve from the step working directory.
+
+## Checkout the Default Branch
+
+Omit `ref` to checkout the repository default HEAD. On repeated runs against an existing checkout, Dagu fetches `origin` and updates the worktree to the current remote default HEAD.
+
+```yaml
+steps:
+  - id: checkout_docs
+    action: git.checkout
+    with:
+      repository: https://github.com/example/docs.git
+      path: ./repos/docs
+```
+
+## Checkout a Branch, Tag, or Commit
+
+`ref` can be a branch name, tag name, remote ref, or commit hash.
+
+```yaml
+steps:
+  - id: checkout_release
+    action: git.checkout
+    with:
+      repository: https://github.com/example/app.git
+      ref: v1.4.2
+      path: ./repos/app
+```
+
+```yaml
+steps:
+  - id: checkout_commit
+    action: git.checkout
+    with:
+      repository: https://github.com/example/app.git
+      ref: 4f8e4d4a9d81c4f4a7300a2d8e1a1c4f7e3c2b10
+      path: ./repos/app
+```
+
+The checkout resolves the requested ref to a commit and updates the worktree to that commit.
+
+## Shallow Checkout
+
+Set `depth` to use shallow clone and fetch operations. Use `0` or omit the field for full history.
+
+```yaml
+steps:
+  - id: checkout_fast
+    action: git.checkout
+    with:
+      repository: https://github.com/example/app.git
+      ref: main
+      path: ./repos/app
+      depth: 1
+```
+
+## Authentication
+
+### HTTPS Token
+
+```yaml
+secrets:
+  - name: GITHUB_TOKEN
+    provider: env
+    key: GITHUB_TOKEN
+
+steps:
+  - id: checkout_private
+    action: git.checkout
+    with:
+      repository: https://github.com/example/private-repo.git
+      ref: main
+      path: ./repos/private-repo
+      token: ${GITHUB_TOKEN}
+```
+
+### HTTPS Username and Password
+
+```yaml
+secrets:
+  - name: GIT_PASSWORD
+    provider: env
+    key: GIT_PASSWORD
+
+steps:
+  - id: checkout_with_password
+    action: git.checkout
+    with:
+      repository: https://git.example.com/team/repo.git
+      path: ./repos/repo
+      username: deploy
+      password: ${GIT_PASSWORD}
+```
+
+### SSH Key
+
+```yaml
+steps:
+  - id: checkout_over_ssh
+    action: git.checkout
+    with:
+      repository: git@github.com:example/private-repo.git
+      ref: main
+      path: ./repos/private-repo
+      ssh_key_path: /home/dagu/.ssh/deploy_key
+```
+
+Use `ssh_passphrase` when the private key is encrypted.
+
+## Configuration
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `repository` | string | Yes | - | Git repository URL or local repository path. |
+| `path` | string | Yes | - | Destination checkout path. Relative paths resolve from the step working directory. |
+| `ref` | string | No | repository default HEAD | Branch, tag, remote ref, or commit to checkout. |
+| `depth` | integer | No | `0` | Shallow clone/fetch depth. `0` means full history. |
+| `force` | boolean | No | `false` | Force checkout when the existing worktree has local changes. |
+| `token` | string | No | - | HTTPS token for repository authentication. |
+| `username` | string | No | `git` when `password` is set | HTTPS username for password authentication. |
+| `password` | string | No | - | HTTPS password for repository authentication. |
+| `ssh_key_path` | string | No | - | Path to an SSH private key. |
+| `ssh_passphrase` | string | No | - | Passphrase for `ssh_key_path`. |
+
+`token` cannot be combined with `username` or `password`. `ssh_key_path` cannot be combined with `token` or `password`.
+
+## Output
+
+The action writes a JSON result to stdout. Capture it with `output:` when later steps need the resolved commit.
+
+```yaml
+steps:
+  - id: checkout_source
+    action: git.checkout
+    with:
+      repository: https://github.com/example/app.git
+      ref: main
+      path: ./repos/app
+    output: CHECKOUT
+
+  - id: print_commit
+    run: echo "Checked out ${checkout_source.output.commit}"
+```
+
+Example output:
+
+```json
+{
+  "operation": "checkout",
+  "path": "/workspace/repos/app",
+  "ref": "main",
+  "commit": "4f8e4d4a9d81c4f4a7300a2d8e1a1c4f7e3c2b10",
+  "cloned": true,
+  "changed": true
+}
+```
+
+## Existing Paths
+
+If `path` already contains a Git repository, Dagu fetches `origin` and checks out the requested ref. If `path` exists but is not a Git repository, it must be empty; otherwise the step fails to avoid overwriting unrelated files.
+
+Use `force: true` only when the workflow may intentionally discard local worktree changes.
+
+## See Also
+
+- [Git Sync](/server-admin/git-sync) - Server-side synchronization for DAG definitions and managed files
+- [GitHub Integration](/github-integration/) - Trigger Dagu workflows from GitHub events
+- [Shell](/step-types/shell) - Run custom Git commands when you need behavior outside `git.checkout`

--- a/step-types/http.md
+++ b/step-types/http.md
@@ -246,4 +246,4 @@ steps:
     command: POST ${URL}
 ```
 
-See [parallel.items](/writing-workflows/parallel) for full fan-out options.
+See [Parallel Execution](/writing-workflows/execution-control#parallel-execution) for full fan-out options.

--- a/step-types/sql/index.md
+++ b/step-types/sql/index.md
@@ -344,7 +344,7 @@ steps:
       ALTER TABLE orders ADD COLUMN IF NOT EXISTS processed_at TIMESTAMPTZ;
 ```
 
-See [parallel.items](/writing-workflows/parallel) for full fan-out options.
+See [Parallel Execution](/writing-workflows/execution-control#parallel-execution) for full fan-out options.
 
 ## See Also
 

--- a/step-types/ssh.md
+++ b/step-types/ssh.md
@@ -334,7 +334,7 @@ steps:
     command: uptime
 ```
 
-See [parallel.items](/writing-workflows/parallel) for full fan-out options.
+See [Parallel Execution](/writing-workflows/execution-control#parallel-execution) for full fan-out options.
 
 ## See Also
 

--- a/writing-workflows/yaml-specification.md
+++ b/writing-workflows/yaml-specification.md
@@ -939,6 +939,8 @@ Rules:
 - `exec` cannot be combined with `command`, `script`, `shell`, or `shell_packages`.
 - `working_dir`, `env`, `stdout`, `stderr`, `retry_policy`, `output`, and other normal orchestration fields still apply.
 
+For source repository checkouts, use `action: git.checkout` with `with.repository`, `with.path`, and optional `with.ref`, `with.depth`, or authentication fields. See [Git](/step-types/git) for the full reference.
+
 ### Step Definition Formats
 
 Steps can be defined in multiple formats:


### PR DESCRIPTION
## Summary

- Add a Git action reference page for `git.checkout`.
- Link the page from the VitePress sidebar, homepage, concepts guide, and YAML specification.
- Fix existing broken `parallel.items` links to the Parallel Execution section so the docs build passes.

## Validation

- `pnpm build`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Git step type documentation enabling repository cloning/updating during workflow runs via the `git.checkout` action.
  * Documented configuration options including repository URLs, checkout references, shallow cloning, and authentication methods (HTTPS tokens, credentials, SSH keys).
  * Updated documentation cross-references for parallel execution patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/docs/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->